### PR TITLE
Feature/phantomjs

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,11 +33,14 @@ module.exports = function (config) {
     reporters: config.angularCli && config.angularCli.codeCoverage
               ? ['progress', 'karma-remap-istanbul']
               : ['progress'],
+    phantomJsLauncher: {
+        exitOnResourceError: true
+    },
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Chrome', 'PhantomJS'],
     singleRun: false
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
+      require('karma-phantomjs-launcher'),
       require('karma-remap-istanbul'),
       require('angular-cli/plugins/karma')
     ],
@@ -40,7 +41,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome', 'PhantomJS'],
+    browsers: ['PhantomJS'],
     singleRun: false
   });
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "ng serve",
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",
+    "test:headless": "karma start karma.conf.js --browsers PhantomJS --autoWatch=true --singleRun=false",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor",
     "build:server": "tsc -p src/server",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "jasmine-core": "2.5.2",
     "jasmine-spec-reporter": "2.5.0",
     "karma": "1.2.0",
+    "karma-phantomjs-launcher": "1.0.2",
+    "phantomjs-prebuilt": "2.1.14",
     "karma-chrome-launcher": "^2.0.0",
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -21,17 +21,17 @@ describe('AppComponent', () => {
     TestBed.compileComponents();
   });
 
-  it('should create the app', async(() => {
+  it('should create the app',() => {
     let fixture = TestBed.createComponent(AppComponent);
     let app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
-  }));
+  });
 
-  it(`should have as title 'Eventim Dashboard'`, async(() => {
+  it(`should have as title 'Eventim Dashboard'`, () => {
     let fixture = TestBed.createComponent(AppComponent);
     let app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('Eventim Dashboard');
-  }));
+  });
 
   it('should render title in a h1 tag', () => {
     let fixture = TestBed.createComponent(AppComponent);

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,17 +1,22 @@
 /* tslint:disable:no-unused-variable */
 
 import { TestBed, async } from '@angular/core/testing';
-import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
+import { TimeWidgetComponent} from './time-widget/time-widget.component';
+import { NewsWidgetComponent} from './news-widget/news-widget.component';
+import { MessageService } from './message.service';
 
 describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppModule,
-        AppComponent
+        AppComponent,
+        TimeWidgetComponent,
+        NewsWidgetComponent
       ],
-      providers: []
+      providers: [
+        MessageService
+      ]
     });
     TestBed.compileComponents();
   });
@@ -23,7 +28,6 @@ describe('AppComponent', () => {
   }));
 
   it(`should have as title 'Eventim Dashboard'`, async(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 6000;
     let fixture = TestBed.createComponent(AppComponent);
     let app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('Eventim Dashboard');

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,22 +1,17 @@
 /* tslint:disable:no-unused-variable */
 
 import { TestBed, async } from '@angular/core/testing';
+import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
-import { TimeWidgetComponent} from './time-widget/time-widget.component';
-import { NewsWidgetComponent} from './news-widget/news-widget.component';
-import { MessageService } from './message.service';
 
 describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        TimeWidgetComponent,
-        NewsWidgetComponent
+        AppModule,
+        AppComponent
       ],
-      providers: [
-        MessageService
-      ]
+      providers: []
     });
     TestBed.compileComponents();
   });
@@ -28,6 +23,7 @@ describe('AppComponent', () => {
   }));
 
   it(`should have as title 'Eventim Dashboard'`, async(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 6000;
     let fixture = TestBed.createComponent(AppComponent);
     let app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('Eventim Dashboard');


### PR DESCRIPTION
Ich hab PhantomJS als Headless Test Browser statt des Chrome integriert und ich habe die Tests wieder grün gemacht. Wieso der Async Callback auf einmal auf die Nase fällt? Keine Ahnung, aber jetzt geht's wieder ... 

Wir müssen eh mehr auf die Tests und auf die Coverage achten ... 